### PR TITLE
limit ghc to 7.8 and later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,81 @@
-language: haskell
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.2
+      compiler: ": #GHC 7.10.2"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/pipes-http.cabal
+++ b/pipes-http.cabal
@@ -1,5 +1,5 @@
 Name: pipes-http
-Version: 1.0.3
+Version: 1.0.4
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3

--- a/pipes-http.cabal
+++ b/pipes-http.cabal
@@ -1,5 +1,5 @@
 Name: pipes-http
-Version: 1.0.2
+Version: 1.0.3
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3
@@ -11,17 +11,18 @@ Bug-Reports: https://github.com/Gabriel439/Haskell-Pipes-HTTP-Library/issues
 Synopsis: HTTP client with pipes interface
 Description: @pipes-http@ is a @pipes@ wrapper around the @http-client@ library
 Category: Pipes, Web
+Tested-With: GHC == 7.8.4, GHC == 7.10.2, GHC == 8.0.1
 Source-Repository head
     Type: git
     Location: https://github.com/Gabriel439/Haskell-Pipes-HTTP-Library
-
 Library
     HS-Source-Dirs: src
     Build-Depends:
         base             >= 4       && < 5   ,
-        bytestring       >= 0.9.2.1 && < 0.11,
-        pipes            >= 4.0     && < 4.2 ,
-        http-client      >= 0.2     && < 0.5 ,
-        http-client-tls                < 0.3
+        bytestring       >= 0.10.0 && < 0.11,
+        pipes            >= 4.0     && < 4.3 ,
+        http-client      >= 0.2     && < 0.6 ,
+        http-client-tls                < 0.4
     Exposed-Modules: Pipes.HTTP
     GHC-Options: -O2 -Wall
+


### PR DESCRIPTION
I  generated the `.travis.yml` with https://github.com/hvr/multi-ghc-travis (adding the required  `tested-with` stanza to the `cabal` file.) I omitted a `cabal check` test since it doesn't like the `-O2` option.  This should correspond to https://travis-ci.org/michaelt/Haskell-Pipes-HTTP-Library/builds/146379763 
